### PR TITLE
Fix: vercel.json updated for deployment.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "functions": {
     "api/*.js": {
       "memory": 128,
-      "maxDuration": 30
+      "maxDuration": 10
     }
   },
   "redirects": [


### PR DESCRIPTION
Field 'maxDuration' caused error when deploying to a free Vercel plan.